### PR TITLE
feat: extend annotations

### DIFF
--- a/src/accessors/getAnnotations.ts
+++ b/src/accessors/getAnnotations.ts
@@ -2,7 +2,7 @@ import type { SchemaAnnotations } from '../nodes/types';
 import type { SchemaFragment } from '../types';
 import { pick } from '../utils/pick';
 
-const ANNOTATIONS: SchemaAnnotations[] = ['description', 'default', 'examples'];
+const ANNOTATIONS: SchemaAnnotations[] = ['description', 'default', 'examples', 'const', 'x-example'];
 
 export function getAnnotations(fragment: SchemaFragment) {
   return pick(fragment, ANNOTATIONS);

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -25,6 +25,6 @@ export enum SchemaCombinerName {
   OneOf = 'oneOf',
 }
 
-export type SchemaAnnotations = 'description' | 'default' | 'examples';
+export type SchemaAnnotations = 'description' | 'default' | 'examples' | 'const' | 'x-example';
 
 export type SchemaMeta = 'id' | '$schema';


### PR DESCRIPTION
Needed by https://github.com/stoplightio/json-schema-viewer/pull/105
Adds `const` and `x-example` properties to annotations.