### PR TITLE
fix(walker): reuse allOfs correctly

### DIFF
--- a/src/__tests__/__fixtures__/combiners/allOfs/circular-regular-level.json
+++ b/src/__tests__/__fixtures__/combiners/allOfs/circular-regular-level.json
@@ -1,0 +1,29 @@
+{
+  "properties": {
+    "someProp": {
+      "$ref": "#/__bundled__/repo"
+    }
+  },
+  "__bundled__": {
+    "repo": {
+      "properties": {
+        "parent": {
+          "allOf": [
+            {
+              "$ref": "#/__bundled__/repo"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "foo": {
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/src/__tests__/__fixtures__/combiners/allOfs/circular-top-level.json
+++ b/src/__tests__/__fixtures__/combiners/allOfs/circular-top-level.json
@@ -1,0 +1,20 @@
+{
+  "$ref": "#/__bundled__/repo",
+  "__bundled__": {
+    "repo": {
+      "properties": {
+        "parent": {
+          "allOf": [
+            {
+              "$ref": "#/__bundled__/repo"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/src/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/src/__tests__/__snapshots__/tree.spec.ts.snap
@@ -554,6 +554,53 @@ exports[`SchemaTree output should generate valid tree for combiners/allOfs/base.
 "
 `;
 
+exports[`SchemaTree output should generate valid tree for combiners/allOfs/circular-regular-level.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/properties/someProp
+            ├─ types
+            │  └─ 0: object
+            ├─ primaryType: object
+            └─ children
+               └─ 0
+                  └─ #/properties/someProp/properties/parent
+                     ├─ types
+                     │  └─ 0: object
+                     ├─ primaryType: object
+                     └─ children
+                        ├─ 0
+                        │  └─ #/properties/someProp/properties/parent/properties/parent
+                        │     └─ mirrors: #/properties/someProp/properties/parent
+                        └─ 1
+                           └─ #/properties/someProp/properties/parent/properties/foo
+                              ├─ types
+                              │  └─ 0: string
+                              └─ primaryType: string
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for combiners/allOfs/circular-top-level.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/properties/parent
+            ├─ types
+            │  └─ 0: object
+            ├─ primaryType: object
+            └─ children
+               └─ 0
+                  └─ #/properties/parent/properties/parent
+                     └─ mirrors: #/properties/parent
+"
+`;
+
 exports[`SchemaTree output should generate valid tree for combiners/allOfs/complex.json 1`] = `
 "└─ #
    ├─ types

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -301,14 +301,14 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       try {
         const merged = mergeOneOrAnyOf(fragment, path, walkingOptions);
         if (merged.length === 1) {
-          return [new RegularNode(merged[0]), fragment];
+          return [new RegularNode(merged[0]), initialFragment];
         } else {
           const combiner = SchemaCombinerName.OneOf in fragment ? SchemaCombinerName.OneOf : SchemaCombinerName.AnyOf;
           return [
             new RegularNode({
               [combiner]: merged,
             }),
-            fragment,
+            initialFragment,
           ];
         }
       } catch (ex) {


### PR DESCRIPTION
Fixes https://github.com/stoplightio/json-schema-tree/issues/6

The issue is mostly caused by the fact `json-schema-merge-allof` creates a object, and therefore `processedFragments` check is missed. This is why I resorted to relying on `allOf` rather than the whole fragment.
`allOf` itself is stable and not cloned.

On a side note - although I haven't measured the perf difference, I suppose we should see some gains in certain situations (such as more than a single $ref to the same allOf).

The current JSV (3.x.x) is also vulnerable to the same issue - it handles it worse than the new version of JSV (v4) will, as the current version just keeps populating the tree until it eventually fails (see the error in the console).

![image](https://user-images.githubusercontent.com/9273484/113420773-306c1a80-93ca-11eb-8c30-784aa03ae11a.png)


This is how it looks like when yalced in JSV v4.

![image](https://user-images.githubusercontent.com/9273484/113420113-023a0b00-93c9-11eb-9fa3-e0a15232a1f3.png)
![image](https://user-images.githubusercontent.com/9273484/113420138-1251ea80-93c9-11eb-8378-da7a6528c6e7.png)
![image](https://user-images.githubusercontent.com/9273484/113420711-103c5b80-93ca-11eb-9796-9df09325b6bb.png)

Rows are collapsible now!
