### PR TITLE
feat: preserve original ref info

### DIFF
--- a/src/__tests__/tree.spec.ts
+++ b/src/__tests__/tree.spec.ts
@@ -122,7 +122,7 @@ describe('SchemaTree', () => {
 
         const topLevelObject = tree.root.children[0] as RegularNode;
         const fooObj = topLevelObject.children!.find(child => child.path[child.path.length - 1] === 'foo')!;
-        expect(isRegularNode(fooObj) && fooObj.context.originalRef).toBe('#/properties/bar');
+        expect(isRegularNode(fooObj) && fooObj.originalFragment.$ref).toBe('#/properties/bar');
       });
 
       it('given an array with $reffed items, should resolve', () => {

--- a/src/mergers/mergeOneOrAnyOf.ts
+++ b/src/mergers/mergeOneOrAnyOf.ts
@@ -28,14 +28,13 @@ export function mergeOneOrAnyOf(
       const prunedSchema = { ...fragment };
       delete prunedSchema[combiner];
 
-      const resolvedItem =
-        typeof item.$ref === 'string' && walkingOptions.resolveRef !== null
-          ? walkingOptions.resolveRef(null, item.$ref)
-          : item;
-
       if (Object.keys(prunedSchema).length === 0) {
-        merged.push(resolvedItem);
+        merged.push(item);
       } else {
+        const resolvedItem =
+          typeof item.$ref === 'string' && walkingOptions.resolveRef !== null
+            ? walkingOptions.resolveRef(null, item.$ref)
+            : item;
         const mergedSchema = {
           allOf: [prunedSchema, resolvedItem],
         };

--- a/src/nodes/RegularNode.ts
+++ b/src/nodes/RegularNode.ts
@@ -31,8 +31,9 @@ export class RegularNode extends BaseNode {
   public readonly meta: Readonly<Partial<Dictionary<unknown, SchemaMeta>>>;
   public readonly annotations: Readonly<Partial<Dictionary<unknown, SchemaAnnotations>>>;
   public readonly validations: Readonly<Dictionary<unknown>>;
+  public readonly context: Readonly<{ originalRef?: string }>;
 
-  constructor(public readonly fragment: SchemaFragment) {
+  constructor(public readonly fragment: SchemaFragment, context?: { originalRef?: string }) {
     super(fragment);
 
     this.types = getTypes(fragment);
@@ -48,6 +49,7 @@ export class RegularNode extends BaseNode {
     this.meta = getMeta(fragment);
     this.annotations = getAnnotations(fragment);
     this.validations = getValidations(fragment, this.types);
+    this.context = context ?? {};
 
     this.children = void 0;
   }

--- a/src/nodes/RegularNode.ts
+++ b/src/nodes/RegularNode.ts
@@ -31,9 +31,9 @@ export class RegularNode extends BaseNode {
   public readonly meta: Readonly<Partial<Dictionary<unknown, SchemaMeta>>>;
   public readonly annotations: Readonly<Partial<Dictionary<unknown, SchemaAnnotations>>>;
   public readonly validations: Readonly<Dictionary<unknown>>;
-  public readonly context: Readonly<{ originalRef?: string }>;
+  public readonly originalFragment: SchemaFragment;
 
-  constructor(public readonly fragment: SchemaFragment, context?: { originalRef?: string }) {
+  constructor(public readonly fragment: SchemaFragment, context?: { originalFragment?: SchemaFragment }) {
     super(fragment);
 
     this.types = getTypes(fragment);
@@ -49,7 +49,7 @@ export class RegularNode extends BaseNode {
     this.meta = getMeta(fragment);
     this.annotations = getAnnotations(fragment);
     this.validations = getValidations(fragment, this.types);
-    this.context = context ?? {};
+    this.originalFragment = context?.originalFragment ?? fragment;
 
     this.children = void 0;
   }

--- a/src/nodes/mirrored/MirroredRegularNode.ts
+++ b/src/nodes/mirrored/MirroredRegularNode.ts
@@ -22,6 +22,7 @@ export class MirroredRegularNode extends BaseNode implements RegularNode {
   public readonly meta!: Readonly<Partial<Dictionary<unknown, SchemaMeta>>>;
   public readonly annotations!: Readonly<Partial<Dictionary<unknown, SchemaAnnotations>>>;
   public readonly validations!: Readonly<Dictionary<unknown>>;
+  public readonly context!: Readonly<{ originalRef?: string }>;
 
   public readonly simple!: boolean;
   public readonly unknown!: boolean;

--- a/src/nodes/mirrored/MirroredRegularNode.ts
+++ b/src/nodes/mirrored/MirroredRegularNode.ts
@@ -30,8 +30,9 @@ export class MirroredRegularNode extends BaseNode implements RegularNode {
 
   private readonly cache: WeakMap<RegularNode | ReferenceNode, MirroredRegularNode | MirroredReferenceNode>;
 
-  constructor(public readonly mirroredNode: RegularNode) {
+  constructor(public readonly mirroredNode: RegularNode, context?: { originalFragment?: SchemaFragment }) {
     super(mirroredNode.fragment);
+    this.originalFragment = context?.originalFragment ?? mirroredNode.originalFragment;
 
     this.cache = new WeakMap();
 

--- a/src/nodes/mirrored/MirroredRegularNode.ts
+++ b/src/nodes/mirrored/MirroredRegularNode.ts
@@ -1,6 +1,7 @@
 import type { Dictionary } from '@stoplight/types';
 
 import { isRegularNode } from '../../guards';
+import type { SchemaFragment } from '../../types';
 import { isNonNullable } from '../../utils';
 import { BaseNode } from '../BaseNode';
 import type { ReferenceNode } from '../ReferenceNode';
@@ -22,7 +23,7 @@ export class MirroredRegularNode extends BaseNode implements RegularNode {
   public readonly meta!: Readonly<Partial<Dictionary<unknown, SchemaMeta>>>;
   public readonly annotations!: Readonly<Partial<Dictionary<unknown, SchemaAnnotations>>>;
   public readonly validations!: Readonly<Dictionary<unknown>>;
-  public readonly context!: Readonly<{ originalRef?: string }>;
+  public readonly originalFragment!: SchemaFragment;
 
   public readonly simple!: boolean;
   public readonly unknown!: boolean;

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -237,11 +237,14 @@ export class Walker extends EventEmitter<WalkerEmitter> {
     this.schemaNode = schemaNode;
   }
 
-  protected retrieveFromFragment(fragment: SchemaFragment): MirroredSchemaNode | void {
+  protected retrieveFromFragment(
+    fragment: SchemaFragment,
+    originalFragment: SchemaFragment,
+  ): MirroredSchemaNode | void {
     const processedSchemaNode = this.processedFragments.get(fragment);
     if (processedSchemaNode !== void 0) {
       if (isRegularNode(processedSchemaNode)) {
-        return new MirroredRegularNode(processedSchemaNode);
+        return new MirroredRegularNode(processedSchemaNode, { originalFragment });
       }
 
       if (isReferenceNode(processedSchemaNode)) {
@@ -257,7 +260,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
     const { walkingOptions, path, fragment: originalFragment } = this;
     let { fragment } = this;
 
-    let retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment) : null;
+    let retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment, originalFragment) : null;
 
     if (retrieved) {
       return retrieved;
@@ -271,7 +274,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
           fragment = walkingOptions.resolveRef(path, fragment.$ref);
         } catch (ex) {
           super.emit('error', createMagicError(ex));
-          return new ReferenceNode(fragment, ex?.message ?? 'Unknown resolving error');
+          return new ReferenceNode(fragment, ex?.message ?? 'Unknown   resolving error');
         }
       } else {
         return new ReferenceNode(fragment, null);
@@ -302,7 +305,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       }
     }
 
-    retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment) : null;
+    retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment, originalFragment) : null;
 
     if (retrieved) {
       return retrieved;

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -254,9 +254,8 @@ export class Walker extends EventEmitter<WalkerEmitter> {
   }
 
   protected processFragment(): SchemaNode {
-    const { walkingOptions, path } = this;
+    const { walkingOptions, path, fragment: originalFragment } = this;
     let { fragment } = this;
-    const originalRef = typeof fragment.$ref === 'string' ? fragment.$ref : void 0;
 
     let retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment) : null;
 
@@ -292,7 +291,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       try {
         const merged = mergeOneOrAnyOf(fragment, path, walkingOptions);
         if (merged.length === 1) {
-          return new RegularNode(merged[0], { originalRef });
+          return new RegularNode(merged[0], { originalFragment });
         } else {
           const combiner = SchemaCombinerName.OneOf in fragment ? SchemaCombinerName.OneOf : SchemaCombinerName.AnyOf;
           return new RegularNode({
@@ -311,6 +310,6 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       return retrieved;
     }
 
-    return new RegularNode(fragment, { originalRef });
+    return new RegularNode(fragment, { originalFragment });
   }
 }

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -274,7 +274,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
           fragment = walkingOptions.resolveRef(path, fragment.$ref);
         } catch (ex) {
           super.emit('error', createMagicError(ex));
-          return new ReferenceNode(fragment, ex?.message ?? 'Unknown   resolving error');
+          return new ReferenceNode(fragment, ex?.message ?? 'Unknown resolving error');
         }
       } else {
         return new ReferenceNode(fragment, null);

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -256,6 +256,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
   protected processFragment(): SchemaNode {
     const { walkingOptions, path } = this;
     let { fragment } = this;
+    const originalRef = typeof fragment.$ref === 'string' ? fragment.$ref : void 0;
 
     let retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment) : null;
 
@@ -291,7 +292,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       try {
         const merged = mergeOneOrAnyOf(fragment, path, walkingOptions);
         if (merged.length === 1) {
-          return new RegularNode(merged[0]);
+          return new RegularNode(merged[0], { originalRef });
         } else {
           const combiner = SchemaCombinerName.OneOf in fragment ? SchemaCombinerName.OneOf : SchemaCombinerName.AnyOf;
           return new RegularNode({
@@ -310,6 +311,6 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       return retrieved;
     }
 
-    return new RegularNode(fragment);
+    return new RegularNode(fragment, { originalRef });
   }
 }

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -294,9 +294,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
           return new RegularNode(merged[0], { originalFragment });
         } else {
           const combiner = SchemaCombinerName.OneOf in fragment ? SchemaCombinerName.OneOf : SchemaCombinerName.AnyOf;
-          return new RegularNode({
-            [combiner]: merged,
-          });
+          return new RegularNode({ [combiner]: merged }, { originalFragment });
         }
       } catch (ex) {
         super.emit('error', createMagicError(new MergingError(ex?.message ?? 'Unknown merging error')));


### PR DESCRIPTION
Needed for https://github.com/stoplightio/json-schema-viewer/issues/125

Adds a new `context` property to `RegularNode` that lets us store auxiliary info, such as the original $ref string we need for JSV125.

LMK if this is a good place to put it, or rather it should go into `meta` or similar?