### PR TITLE
fix(mergeallof): make sure fragment is fully merged

### DIFF
--- a/src/mergers/mergeAllOf.ts
+++ b/src/mergers/mergeAllOf.ts
@@ -59,9 +59,9 @@ export function mergeAllOf(fragment: SchemaFragment, path: string[], walkingOpti
     store.set(walkingOptions.resolveRef, new WeakMap());
   }
 
-  const merged = _mergeAllOf(fragment, path, walkingOptions.resolveRef);
-  if ('allOf' in merged) {
-    return _mergeAllOf(merged, path, walkingOptions.resolveRef);
+  let merged = _mergeAllOf(fragment, path, walkingOptions.resolveRef);
+  while ('allOf' in merged) {
+    merged = _mergeAllOf(merged, path, walkingOptions.resolveRef);
   }
 
   return merged;


### PR DESCRIPTION
Right now we merge on a fragment at most twice; we have some that require more merge operations to
be fully merged.

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
Issue 10745 (platform) shows that some schemas have a larger allOf nesting tree than we're currently accounting for - we'll cycle through an individual fragment either once or twice (if allOf(s) are still detected) but won't try again after that.  


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
