### PR TITLE
fix (walker): show description for $ref in fragments of type array

### DIFF
--- a/src/__tests__/tree.spec.ts
+++ b/src/__tests__/tree.spec.ts
@@ -757,6 +757,101 @@ describe('SchemaTree', () => {
         }),
       );
     });
+
+    it('node of type array should adopt description of referenced node', () => {
+      const schema = {
+        definitions: {
+          Cave: {
+            type: 'string',
+            summary: 'A cave',
+            description: '_Everyone_ ~hates~ loves caves',
+          },
+        },
+        type: 'object',
+        properties: {
+          caves: {
+            type: 'array',
+            items: {
+              $ref: '#/definitions/Cave',
+            },
+          },
+        },
+      };
+
+      const tree = new SchemaTree(schema);
+      tree.populate();
+
+      expect(
+        // @ts-ignore
+        tree.root.children[0].children[0].annotations.description,
+      ).toEqual('_Everyone_ ~hates~ loves caves');
+    });
+
+    it('node of type array should keep its own description even when referenced node has a description', () => {
+      const schema = {
+        definitions: {
+          Cave: {
+            type: 'string',
+            summary: 'A cave',
+            description: '_Everyone_ ~hates~ loves caves',
+          },
+        },
+        type: 'object',
+        properties: {
+          caves: {
+            type: 'array',
+            description: 'I have my own description',
+            items: {
+              $ref: '#/definitions/Cave',
+            },
+          },
+        },
+      };
+
+      const tree = new SchemaTree(schema);
+      tree.populate();
+
+      expect(
+        // @ts-ignore
+        tree.root.children[0].children[0].annotations.description,
+      ).toEqual('I have my own description');
+    });
+
+    it('referenced node description should appear for all properties with that ref', () => {
+      const schema = {
+        definitions: {
+          Cave: {
+            type: 'string',
+            summary: 'A cave',
+            description: '_Everyone_ ~hates~ loves caves',
+          },
+        },
+        type: 'object',
+        properties: {
+          caves: {
+            type: 'array',
+            items: {
+              $ref: '#/definitions/Cave',
+            },
+          },
+          bear: {
+            $ref: '#/definitions/Cave',
+          },
+        },
+      };
+
+      const tree = new SchemaTree(schema);
+      tree.populate();
+
+      expect(
+        // @ts-ignore
+        tree.root.children[0].children[0].annotations.description,
+      ).toEqual('_Everyone_ ~hates~ loves caves');
+      expect(
+        // @ts-ignore
+        tree.root.children[0].children[1].annotations.description,
+      ).toEqual('_Everyone_ ~hates~ loves caves');
+    });
   });
 
   describe('position', () => {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[#12516](https://app.zenhub.com/workspaces/-team-enchilotters-62ab7d6627416c001df37493/issues/gh/stoplightio/platform-internal/12516)

## Description
<!-- Describe your technical changes in detail. -->
Checks fragment type to see if it's an array without a description. If there's a $ref within the fragment's items, attempts to resolve the $ref to grab the $ref description and assigns it to the fragment so that it will be included in the annotations for that node.

Before
![Screenshot 2023-08-08 at 1 34 52 PM](https://github.com/stoplightio/json-schema-tree/assets/47359669/f00a1bed-1f82-4dfe-ad2e-b76e1b070560)

After
![Screenshot 2023-08-08 at 1 32 19 PM](https://github.com/stoplightio/json-schema-tree/assets/47359669/9460b479-c77a-491b-b55c-a63d26af9ed7)




## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Added tests; yalced into JSON Schema Viewer

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
