### PR TITLE
fix(walker): support circular JSON $refs with overrides

### DIFF
--- a/src/__tests__/__fixtures__/references/circular-with-overrides.json
+++ b/src/__tests__/__fixtures__/references/circular-with-overrides.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "order": {
+      "$ref": "#/definitions/Order",
+      "description": "My Order"
+    }
+  },
+  "definitions": {
+    "Cart": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "$ref": "#/definitions/Order",
+          "description": "My Order"
+        }
+      }
+    },
+    "Order": {
+      "type": "object",
+      "properties": {
+        "member": {
+          "$ref": "#/definitions/Member",
+          "description": "Member"
+        }
+      }
+    },
+    "Member": {
+      "type": "object",
+      "properties": {
+        "referredMember": {
+          "$ref": "#/definitions/Member",
+          "description": "Member"
+        }
+      }
+    }
+  }
+}

--- a/src/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/src/__tests__/__snapshots__/tree.spec.ts.snap
@@ -1279,6 +1279,36 @@ exports[`SchemaTree output should generate valid tree for references/base.json 1
 "
 `;
 
+exports[`SchemaTree output should generate valid tree for references/circular-with-overrides.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/properties/order
+            ├─ types
+            │  └─ 0: object
+            ├─ primaryType: object
+            └─ children
+               └─ 0
+                  └─ #/properties/order/properties/member
+                     ├─ types
+                     │  └─ 0: object
+                     ├─ primaryType: object
+                     └─ children
+                        └─ 0
+                           └─ #/properties/order/properties/member/properties/referredMember
+                              ├─ types
+                              │  └─ 0: object
+                              ├─ primaryType: object
+                              └─ children
+                                 └─ 0
+                                    └─ #/properties/order/properties/member/properties/referredMember/properties/referredMember
+                                       └─ mirrors: #/properties/order/properties/member/properties/referredMember
+"
+`;
+
 exports[`SchemaTree output should generate valid tree for references/nullish.json 1`] = `
 "└─ #
    ├─ types

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -285,6 +285,8 @@ export class Walker extends EventEmitter<WalkerEmitter> {
       return retrieved;
     }
 
+    let initialFragment: ProcessedFragment = fragment;
+
     if ('$ref' in fragment) {
       if (typeof walkingOptions.maxRefDepth === 'number' && walkingOptions.maxRefDepth < depth) {
         return [new ReferenceNode(fragment, `max $ref depth limit reached`), fragment];
@@ -297,6 +299,11 @@ export class Walker extends EventEmitter<WalkerEmitter> {
           if (typeof fragment.description === 'string') {
             newFragment = { ...newFragment };
             Object.assign(newFragment, { description: fragment.description });
+          } else {
+            retrieved = this.retrieveFromFragment(newFragment, originalFragment);
+            if (retrieved) {
+              return retrieved;
+            }
           }
 
           fragment = newFragment;
@@ -331,7 +338,6 @@ export class Walker extends EventEmitter<WalkerEmitter> {
         }
       }
     }
-    let initialFragment: ProcessedFragment = fragment;
     if (walkingOptions.mergeAllOf && SchemaCombinerName.AllOf in fragment) {
       try {
         if (Array.isArray(fragment.allOf)) {


### PR DESCRIPTION
Related to https://github.com/stoplightio/json-schema-tree/issues/19

The actual fix here is initializing `initialFragment` earlier so that its initially assigned value isn't an already mutated schema fragment.
Unsure whether this will help with the tricky spec, since `allOf` merging might be the bottleneck now

The other change is mostly a little optimization to abort quickly if the resolved fragment has been already processed.