### PR TITLE
fix(json-schema-merge-allof): bump version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {},
   "dependencies": {
     "@stoplight/json": "^3.12.0",
-    "@stoplight/json-schema-merge-allof": "^0.7.8",
+    "@stoplight/json-schema-merge-allof": "^0.8.0",
     "@stoplight/lifecycle": "^2.3.2",
     "@types/json-schema": "^7.0.7",
     "magic-error": "0.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,10 +936,10 @@
   dependencies:
     eslint-config-prettier "^7.1.0"
 
-"@stoplight/json-schema-merge-allof@^0.7.8":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.8.tgz#7efe5e0086dff433eb011f617e82f7295c3de061"
-  integrity sha512-JTDt6GYpCWQSb7+UW1P91IAp/pcLWis0mmEzWVFcLsrNgtUYK7JLtYYz0ZPSR4QVL0fJ0YQejM+MPq5iNDFO4g==
+"@stoplight/json-schema-merge-allof@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.8.0.tgz#62f8116f59d9df5a910d037b1965decd2efab472"
+  integrity sha512-g8e0s43v96Xbzvd8d6KKUuJTO16CS2oJglJrviUi8ASIUxzFvAJqTHWLtGmpTryisQopqg1evXGJfi0+164+Qw==
   dependencies:
     compute-lcm "^1.1.0"
     json-schema-compare "^0.2.2"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/stoplightio/elements/issues/2419

description and summary key/values are being overridden when siblings to reference in an allOf

## Description
<!-- Describe your technical changes in detail. -->
Bumped version of json-schema-merge-allOf
The new version retains siblings of references if they are description or summary key/values

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Added a new test for an allOf schema that has a reference with a description sibling

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
