### PR TITLE
feat: support booleanish schemas & represent additional{Items,Properties}

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   rootDir: process.cwd(),
   testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
   setupFilesAfterEnv: ['./setupTests.ts'],
   testMatch: ['<rootDir>/src/**/__tests__/*.(ts|js)?(x)'],
   transform: {

--- a/src/__tests__/__fixtures__/arrays/additional-empty.json
+++ b/src/__tests__/__fixtures__/arrays/additional-empty.json
@@ -1,0 +1,4 @@
+{
+  "type": "array",
+  "additionalItems": {}
+}

--- a/src/__tests__/__fixtures__/arrays/additional-false.json
+++ b/src/__tests__/__fixtures__/arrays/additional-false.json
@@ -1,0 +1,4 @@
+{
+  "type": "array",
+  "additionalItems": false
+}

--- a/src/__tests__/__fixtures__/arrays/additional-schema.json
+++ b/src/__tests__/__fixtures__/arrays/additional-schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "array",
+  "additionalItems": {
+    "type": "object",
+    "properties": {
+      "baz": {
+        "type": "number"
+      }
+    }
+  }
+}

--- a/src/__tests__/__fixtures__/arrays/additional-true.json
+++ b/src/__tests__/__fixtures__/arrays/additional-true.json
@@ -1,0 +1,4 @@
+{
+  "type": "array",
+  "additionalItems": true
+}

--- a/src/__tests__/__fixtures__/arrays/with-multiple-arrayish-items.json
+++ b/src/__tests__/__fixtures__/arrays/with-multiple-arrayish-items.json
@@ -17,10 +17,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "code",
-        "msg"
-      ]
+      "required": ["code", "msg"]
     }
   ]
 }

--- a/src/__tests__/__fixtures__/arrays/with-single-arrayish-items.json
+++ b/src/__tests__/__fixtures__/arrays/with-single-arrayish-items.json
@@ -14,10 +14,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "code",
-        "msg"
-      ]
+      "required": ["code", "msg"]
     }
   ]
 }

--- a/src/__tests__/__fixtures__/objects/additional-empty.json
+++ b/src/__tests__/__fixtures__/objects/additional-empty.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "additionalProperties": {}
+}

--- a/src/__tests__/__fixtures__/objects/additional-false.json
+++ b/src/__tests__/__fixtures__/objects/additional-false.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "additionalProperties": false
+}

--- a/src/__tests__/__fixtures__/objects/additional-schema.json
+++ b/src/__tests__/__fixtures__/objects/additional-schema.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "baz": {
+        "type": "number"
+      }
+    }
+  }
+}

--- a/src/__tests__/__fixtures__/objects/additional-true.json
+++ b/src/__tests__/__fixtures__/objects/additional-true.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "additionalProperties": true
+}

--- a/src/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/src/__tests__/__snapshots__/tree.spec.ts.snap
@@ -300,7 +300,10 @@ exports[`SchemaTree output should generate valid tree for arrays/additional-empt
 "└─ #
    ├─ types
    │  └─ 0: array
-   └─ primaryType: array
+   ├─ primaryType: array
+   └─ children
+      └─ 0
+         └─ #/additionalItems
 "
 `;
 
@@ -308,7 +311,11 @@ exports[`SchemaTree output should generate valid tree for arrays/additional-fals
 "└─ #
    ├─ types
    │  └─ 0: array
-   └─ primaryType: array
+   ├─ primaryType: array
+   └─ children
+      └─ 0
+         └─ #/additionalItems
+            └─ value: false
 "
 `;
 
@@ -316,7 +323,19 @@ exports[`SchemaTree output should generate valid tree for arrays/additional-sche
 "└─ #
    ├─ types
    │  └─ 0: array
-   └─ primaryType: array
+   ├─ primaryType: array
+   └─ children
+      └─ 0
+         └─ #/additionalItems
+            ├─ types
+            │  └─ 0: object
+            ├─ primaryType: object
+            └─ children
+               └─ 0
+                  └─ #/additionalItems/properties/baz
+                     ├─ types
+                     │  └─ 0: number
+                     └─ primaryType: number
 "
 `;
 
@@ -324,7 +343,11 @@ exports[`SchemaTree output should generate valid tree for arrays/additional-true
 "└─ #
    ├─ types
    │  └─ 0: array
-   └─ primaryType: array
+   ├─ primaryType: array
+   └─ children
+      └─ 0
+         └─ #/additionalItems
+            └─ value: true
 "
 `;
 

--- a/src/__tests__/__snapshots__/tree.spec.ts.snap
+++ b/src/__tests__/__snapshots__/tree.spec.ts.snap
@@ -296,6 +296,38 @@ exports[`SchemaTree output compound keywords given oneOf combiner placed next to
 "
 `;
 
+exports[`SchemaTree output should generate valid tree for arrays/additional-empty.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: array
+   └─ primaryType: array
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for arrays/additional-false.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: array
+   └─ primaryType: array
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for arrays/additional-schema.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: array
+   └─ primaryType: array
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for arrays/additional-true.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: array
+   └─ primaryType: array
+"
+`;
+
 exports[`SchemaTree output should generate valid tree for arrays/of-allofs.json 1`] = `
 "└─ #
    ├─ types
@@ -823,7 +855,16 @@ exports[`SchemaTree output should generate valid tree for combiners/allOfs/neste
       │  └─ #/properties/order
       │     ├─ types
       │     │  └─ 0: object
-      │     └─ primaryType: object
+      │     ├─ primaryType: object
+      │     └─ children
+      │        └─ 0
+      │           └─ #/properties/order/additionalProperties
+      │              ├─ types
+      │              │  └─ 0: string
+      │              ├─ primaryType: string
+      │              └─ enum
+      │                 ├─ 0: ASC
+      │                 └─ 1: DESC
       └─ 7
          └─ #/properties/nextToken
             ├─ types
@@ -1243,6 +1284,61 @@ exports[`SchemaTree output should generate valid tree for formats-schema.json 1`
                               ├─ types
                               │  └─ 0: integer
                               └─ primaryType: integer
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for objects/additional-empty.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/additionalProperties
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for objects/additional-false.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/additionalProperties
+            └─ value: false
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for objects/additional-schema.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/additionalProperties
+            ├─ types
+            │  └─ 0: object
+            ├─ primaryType: object
+            └─ children
+               └─ 0
+                  └─ #/additionalProperties/properties/baz
+                     ├─ types
+                     │  └─ 0: number
+                     └─ primaryType: number
+"
+`;
+
+exports[`SchemaTree output should generate valid tree for objects/additional-true.json 1`] = `
+"└─ #
+   ├─ types
+   │  └─ 0: object
+   ├─ primaryType: object
+   └─ children
+      └─ 0
+         └─ #/additionalProperties
+            └─ value: true
 "
 `;
 

--- a/src/__tests__/tree.spec.ts
+++ b/src/__tests__/tree.spec.ts
@@ -907,6 +907,34 @@ describe('SchemaTree', () => {
         tree.root.children[0].children[1].annotations.description,
       ).toEqual('_Everyone_ ~hates~ loves caves');
     });
+
+    it('should render true/false schemas', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          bear: true,
+          cave: false,
+        },
+      };
+
+      const tree = new SchemaTree(schema);
+      tree.populate();
+
+      expect(printTree(schema)).toMatchInlineSnapshot(`
+        "└─ #
+           ├─ types
+           │  └─ 0: object
+           ├─ primaryType: object
+           └─ children
+              ├─ 0
+              │  └─ #/properties/bear
+              │     └─ value: true
+              └─ 1
+                 └─ #/properties/cave
+                    └─ value: false
+        "
+      `);
+    });
   });
 
   describe('position', () => {

--- a/src/__tests__/utils/printTree.ts
+++ b/src/__tests__/utils/printTree.ts
@@ -2,8 +2,9 @@ import { pathToPointer } from '@stoplight/json';
 import type { Dictionary } from '@stoplight/types';
 import * as treeify from 'treeify';
 
-import { isMirroredNode, isReferenceNode, isRegularNode } from '../../guards';
+import { isBooleanishNode, isMirroredNode, isReferenceNode, isRegularNode, isRootNode } from '../../guards';
 import type { MirroredSchemaNode, ReferenceNode, RegularNode, SchemaNode } from '../../nodes';
+import type { BooleanishNode } from '../../nodes/BooleanishNode';
 import type { SchemaTreeOptions } from '../../tree';
 import { SchemaTree } from '../../tree';
 import type { SchemaFragment } from '../../types';
@@ -41,6 +42,12 @@ function printReferenceNode(node: ReferenceNode) {
   };
 }
 
+function printBooleanishNode(node: BooleanishNode) {
+  return {
+    value: node.fragment,
+  };
+}
+
 function printMirrorNode(node: MirroredSchemaNode): any {
   return {
     mirrors: pathToPointer(node.mirroredNode.path as string[]),
@@ -48,15 +55,17 @@ function printMirrorNode(node: MirroredSchemaNode): any {
 }
 
 function printNode(node: SchemaNode) {
-  return isMirroredNode(node)
-    ? printMirrorNode(node)
-    : isRegularNode(node)
-    ? printRegularNode(node)
-    : isReferenceNode(node)
-    ? printReferenceNode(node)
-    : {
-        kind: 'unknown node',
-      };
+  if (isMirroredNode(node)) {
+    return printMirrorNode(node);
+  } else if (isRegularNode(node)) {
+    return printRegularNode(node);
+  } else if (isReferenceNode(node)) {
+    return printReferenceNode(node);
+  } else if (isBooleanishNode(node)) {
+    return printBooleanishNode(node);
+  } else if (isRootNode(node)) {
+    return {};
+  }
 }
 
 function prepareTree(node: SchemaNode) {

--- a/src/accessors/getValidations.ts
+++ b/src/accessors/getValidations.ts
@@ -12,8 +12,8 @@ const VALIDATION_TYPES: Partial<Dictionary<(keyof SchemaFragment)[], SchemaNodeK
   get integer() {
     return this.number;
   },
-  object: ['additionalProperties', 'minProperties', 'maxProperties'],
-  array: ['additionalItems', 'minItems', 'maxItems', 'uniqueItems'],
+  object: ['minProperties', 'maxProperties'],
+  array: ['minItems', 'maxItems', 'uniqueItems'],
 };
 
 function getTypeValidations(types: SchemaNodeKind[]): (keyof SchemaFragment)[] | null {

--- a/src/guards/nodes.ts
+++ b/src/guards/nodes.ts
@@ -7,6 +7,7 @@ import {
   RootNode,
   SchemaNode,
 } from '../nodes';
+import type { BooleanishNode } from '../nodes/BooleanishNode';
 
 export function isSchemaNode(node: unknown): node is SchemaNode {
   const name = Object.getPrototypeOf(node).constructor.name;
@@ -33,4 +34,8 @@ export function isMirroredNode(node: SchemaNode): node is MirroredSchemaNode {
 
 export function isReferenceNode(node: SchemaNode): node is ReferenceNode {
   return 'external' in node && 'value' in node;
+}
+
+export function isBooleanishNode(node: SchemaNode): node is BooleanishNode {
+  return typeof node.fragment === 'boolean';
 }

--- a/src/nodes/BaseNode.ts
+++ b/src/nodes/BaseNode.ts
@@ -1,4 +1,3 @@
-import type { SchemaFragment } from '../types';
 import type { MirroredRegularNode } from './mirrored';
 import type { RegularNode } from './RegularNode';
 import type { RootNode } from './RootNode';
@@ -35,7 +34,7 @@ export abstract class BaseNode {
     return this.pos === this.parentChildren.length - 1;
   }
 
-  protected constructor(public readonly fragment: SchemaFragment) {
+  protected constructor() {
     this.id = String(SEED++);
     this.subpath = [];
   }

--- a/src/nodes/BooleanishNode.ts
+++ b/src/nodes/BooleanishNode.ts
@@ -1,0 +1,7 @@
+import { BaseNode } from './BaseNode';
+
+export class BooleanishNode extends BaseNode {
+  constructor(public readonly fragment: boolean) {
+    super();
+  }
+}

--- a/src/nodes/ReferenceNode.ts
+++ b/src/nodes/ReferenceNode.ts
@@ -7,8 +7,8 @@ import { BaseNode } from './BaseNode';
 export class ReferenceNode extends BaseNode {
   public readonly value: string | null;
 
-  constructor(fragment: SchemaFragment, public readonly error: string | null) {
-    super(fragment);
+  constructor(public readonly fragment: SchemaFragment, public readonly error: string | null) {
+    super();
 
     this.value = unwrapStringOrNull(fragment.$ref);
   }

--- a/src/nodes/RegularNode.ts
+++ b/src/nodes/RegularNode.ts
@@ -10,6 +10,7 @@ import { isDeprecated } from '../accessors/isDeprecated';
 import { unwrapArrayOrNull, unwrapStringOrNull } from '../accessors/unwrap';
 import type { SchemaFragment } from '../types';
 import { BaseNode } from './BaseNode';
+import type { BooleanishNode } from './BooleanishNode';
 import type { ReferenceNode } from './ReferenceNode';
 import { MirroredSchemaNode, SchemaAnnotations, SchemaCombinerName, SchemaNodeKind } from './types';
 
@@ -25,14 +26,14 @@ export class RegularNode extends BaseNode {
   public readonly title: string | null;
   public readonly deprecated: boolean;
 
-  public children: (RegularNode | ReferenceNode | MirroredSchemaNode)[] | null | undefined;
+  public children: (RegularNode | BooleanishNode | ReferenceNode | MirroredSchemaNode)[] | null | undefined;
 
   public readonly annotations: Readonly<Partial<Dictionary<unknown, SchemaAnnotations>>>;
   public readonly validations: Readonly<Dictionary<unknown>>;
   public readonly originalFragment: SchemaFragment;
 
   constructor(public readonly fragment: SchemaFragment, context?: { originalFragment?: SchemaFragment }) {
-    super(fragment);
+    super();
 
     this.$id = unwrapStringOrNull('id' in fragment ? fragment.id : fragment.$id);
     this.types = getTypes(fragment);

--- a/src/nodes/RootNode.ts
+++ b/src/nodes/RootNode.ts
@@ -7,7 +7,7 @@ export class RootNode extends BaseNode {
   public readonly children: SchemaNode[];
 
   constructor(public readonly fragment: SchemaFragment) {
-    super(fragment);
+    super();
     this.children = [];
   }
 }

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -1,4 +1,5 @@
 export { BaseNode } from './BaseNode';
+export { BooleanishNode } from './BooleanishNode';
 export * from './mirrored';
 export { ReferenceNode } from './ReferenceNode';
 export { RegularNode } from './RegularNode';

--- a/src/nodes/mirrored/MirroredReferenceNode.ts
+++ b/src/nodes/mirrored/MirroredReferenceNode.ts
@@ -1,9 +1,13 @@
+import type { SchemaFragment } from '../../types';
 import { BaseNode } from '../BaseNode';
 import type { ReferenceNode } from '../ReferenceNode';
 
 export class MirroredReferenceNode extends BaseNode implements ReferenceNode {
+  public readonly fragment: SchemaFragment;
+
   constructor(public readonly mirroredNode: ReferenceNode) {
-    super(mirroredNode.fragment);
+    super();
+    this.fragment = mirroredNode.fragment;
   }
 
   get error() {

--- a/src/nodes/types.ts
+++ b/src/nodes/types.ts
@@ -1,3 +1,4 @@
+import type { BooleanishNode } from './BooleanishNode';
 import type { MirroredReferenceNode } from './mirrored/MirroredReferenceNode';
 import type { MirroredRegularNode } from './mirrored/MirroredRegularNode';
 import type { ReferenceNode } from './ReferenceNode';
@@ -6,7 +7,7 @@ import type { RootNode } from './RootNode';
 
 export type MirroredSchemaNode = MirroredRegularNode | MirroredReferenceNode;
 
-export type SchemaNode = RootNode | RegularNode | ReferenceNode | MirroredSchemaNode;
+export type SchemaNode = RootNode | RegularNode | BooleanishNode | ReferenceNode | MirroredSchemaNode;
 
 export enum SchemaNodeKind {
   Any = 'any',

--- a/src/utils/guards.ts
+++ b/src/utils/guards.ts
@@ -1,5 +1,7 @@
 import type { Dictionary } from '@stoplight/types';
 
+import type { SchemaFragment } from '../types';
+
 export function isStringOrNumber(value: unknown): value is number | string {
   return typeof value === 'string' || typeof value === 'number';
 }
@@ -22,4 +24,8 @@ export function isObjectLiteral(maybeObj: unknown): maybeObj is Dictionary<unkno
 
 export function isNonNullable<T = unknown>(maybeNullable: T): maybeNullable is NonNullable<T> {
   return maybeNullable !== void 0 && maybeNullable !== null;
+}
+
+export function isValidSchemaFragment(maybeSchemaFragment: unknown): maybeSchemaFragment is SchemaFragment {
+  return typeof maybeSchemaFragment === 'boolean' || isObjectLiteral(maybeSchemaFragment);
 }

--- a/src/walker/types.ts
+++ b/src/walker/types.ts
@@ -13,7 +13,7 @@ export type WalkingOptions = {
 };
 
 export type WalkerSnapshot = {
-  readonly fragment: SchemaFragment;
+  readonly fragment: SchemaFragment | boolean;
   readonly depth: number;
   readonly schemaNode: RegularNode | RootNode;
   readonly path: string[];
@@ -23,7 +23,7 @@ export type WalkerHookAction = 'filter' | 'stepIn';
 export type WalkerHookHandler = (node: SchemaNode) => boolean;
 
 export type WalkerNodeEventHandler = (node: SchemaNode) => void;
-export type WalkerFragmentEventHandler = (node: SchemaFragment) => void;
+export type WalkerFragmentEventHandler = (node: SchemaFragment | boolean) => void;
 export type WalkerErrorEventHandler = (ex: Error) => void;
 
 export type WalkerEmitter = {

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -133,16 +133,16 @@ export class Walker extends EventEmitter<WalkerEmitter> {
     this.fragment = schemaNode.fragment;
     this.depth = initialDepth + 1;
 
+    if (!isRootNode(schemaNode)) {
+      schemaNode.parent = initialSchemaNode;
+      schemaNode.subpath = this.path.slice(initialSchemaNode.path.length);
+    }
+
     const isIncluded = this.hooks.filter?.(schemaNode);
 
     if (isIncluded === false) {
       super.emit('skipNode', schemaNode);
       return;
-    }
-
-    if (!isRootNode(schemaNode)) {
-      schemaNode.parent = initialSchemaNode;
-      schemaNode.subpath = this.path.slice(initialSchemaNode.path.length);
     }
 
     if ('children' in initialSchemaNode && !isRootNode(schemaNode)) {

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -7,10 +7,11 @@ import { isMirroredNode, isReferenceNode, isRegularNode, isRootNode } from '../g
 import { mergeAllOf } from '../mergers/mergeAllOf';
 import { mergeOneOrAnyOf } from '../mergers/mergeOneOrAnyOf';
 import { MirroredReferenceNode, MirroredRegularNode, MirroredSchemaNode, ReferenceNode, RegularNode } from '../nodes';
+import { BooleanishNode } from '../nodes/BooleanishNode';
 import type { RootNode } from '../nodes/RootNode';
 import { SchemaCombinerName, SchemaNode, SchemaNodeKind } from '../nodes/types';
 import type { SchemaFragment } from '../types';
-import { isNonNullable, isObjectLiteral } from '../utils/guards';
+import { isNonNullable, isObjectLiteral, isValidSchemaFragment } from '../utils/guards';
 import type { WalkerEmitter, WalkerHookAction, WalkerHookHandler, WalkerSnapshot, WalkingOptions } from './types';
 
 type InternalWalkerState = {
@@ -25,7 +26,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
   public readonly path: string[];
   public depth: number;
 
-  protected fragment: SchemaFragment;
+  protected fragment: SchemaFragment | boolean;
   protected schemaNode: RegularNode | RootNode;
 
   private mergedAllOfs: WeakMap<SchemaFragment, SchemaFragment>;
@@ -124,8 +125,10 @@ export class Walker extends EventEmitter<WalkerEmitter> {
     super.emit('enterNode', schemaNode);
 
     const actualNode = isMirroredNode(schemaNode) ? schemaNode.mirroredNode : schemaNode;
-    this.processedFragments.set(schemaNode.fragment, actualNode);
-    this.processedFragments.set(initialFragment, actualNode);
+    if (typeof schemaNode.fragment !== 'boolean' && initialFragment !== null) {
+      this.processedFragments.set(schemaNode.fragment, actualNode);
+      this.processedFragments.set(initialFragment, actualNode);
+    }
 
     this.fragment = schemaNode.fragment;
     this.depth = initialDepth + 1;
@@ -186,7 +189,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
   protected walkNodeChildren(): void {
     const { fragment, schemaNode } = this;
 
-    if (!isRegularNode(schemaNode)) return;
+    if (!isRegularNode(schemaNode) || typeof fragment === 'boolean') return;
 
     const state = this.dumpInternalWalkerState();
 
@@ -213,7 +216,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
           let i = -1;
           for (const item of fragment.items) {
             i++;
-            if (!isObjectLiteral(item)) continue;
+            if (!isValidSchemaFragment(item)) continue;
             this.fragment = item;
             this.restoreInternalWalkerState(state);
             this.path.push('items', String(i));
@@ -231,7 +234,7 @@ export class Walker extends EventEmitter<WalkerEmitter> {
         if (isObjectLiteral(fragment.properties)) {
           for (const key of Object.keys(fragment.properties)) {
             const value = fragment.properties[key];
-            if (!isObjectLiteral(value)) continue;
+            if (!isValidSchemaFragment(value)) continue;
             this.fragment = value;
             this.restoreInternalWalkerState(state);
             this.path.push('properties', key);
@@ -242,12 +245,19 @@ export class Walker extends EventEmitter<WalkerEmitter> {
         if (isObjectLiteral(fragment.patternProperties)) {
           for (const key of Object.keys(fragment.patternProperties)) {
             const value = fragment.patternProperties[key];
-            if (!isObjectLiteral(value)) continue;
+            if (!isValidSchemaFragment(value)) continue;
             this.fragment = value;
             this.restoreInternalWalkerState(state);
             this.path.push('patternProperties', key);
             this.walk();
           }
+        }
+
+        if (isValidSchemaFragment(fragment.additionalProperties)) {
+          this.fragment = fragment.additionalProperties;
+          this.restoreInternalWalkerState(state);
+          this.path.push('additionalProperties');
+          this.walk();
         }
 
         break;
@@ -275,11 +285,19 @@ export class Walker extends EventEmitter<WalkerEmitter> {
     }
   }
 
-  protected processFragment(): [SchemaNode, ProcessedFragment] {
+  protected processFragment(): [SchemaNode, ProcessedFragment | null] {
     const { walkingOptions, path, fragment: originalFragment, depth } = this;
     let { fragment } = this;
 
-    let retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment, originalFragment) : null;
+    if (typeof fragment === 'boolean') {
+      return [new BooleanishNode(fragment), null];
+    }
+
+    if (typeof originalFragment === 'boolean') {
+      throw new TypeError('Original fragment cannot be a boolean');
+    }
+
+    let retrieved = isNonNullable(fragment) ? this.retrieveFromFragment(fragment, fragment) : null;
 
     if (retrieved) {
       return retrieved;

--- a/src/walker/walker.ts
+++ b/src/walker/walker.ts
@@ -222,11 +222,20 @@ export class Walker extends EventEmitter<WalkerEmitter> {
             this.path.push('items', String(i));
             this.walk();
           }
-        } else if (isObjectLiteral(fragment.items)) {
-          this.fragment = fragment.items;
-          this.restoreInternalWalkerState(state);
-          this.path.push('items');
-          this.walk();
+        } else {
+          if (isObjectLiteral(fragment.items)) {
+            this.fragment = fragment.items;
+            this.restoreInternalWalkerState(state);
+            this.path.push('items');
+            this.walk();
+          }
+
+          if (isValidSchemaFragment(fragment.additionalItems)) {
+            this.fragment = fragment.additionalItems;
+            this.restoreInternalWalkerState(state);
+            this.path.push('additionalItems');
+            this.walk();
+          }
         }
 
         break;


### PR DESCRIPTION
This PR introduces 2 changes:
- `additionalProperties` and `additionalItems` keywords are now considered as schemas
- a special `BooleanishNode` node type to support true/false schemas

You can see the integration live here https://github.com/stoplightio/json-schema-viewer/pull/249