### PR TITLE
fix(nodes, accessors): fix validations with $ref nodes

### DIFF
--- a/src/accessors/__tests__/getValidations.spec.ts
+++ b/src/accessors/__tests__/getValidations.spec.ts
@@ -12,12 +12,58 @@ describe('getValidations util', () => {
           multipleOf: 2,
         },
         [SchemaNodeKind.Integer],
+        {},
       ),
     ).toStrictEqual({
       exclusiveMaximum: true,
       maximum: 20,
       minimum: 2,
       multipleOf: 2,
+    });
+  });
+  it('should support $ref visibility', () => {
+    expect(
+      getValidations(
+        {
+          readOnly: true,
+        },
+        [SchemaNodeKind.Object],
+        {
+          writeOnly: true,
+        },
+      ),
+    ).toStrictEqual({
+      writeOnly: true,
+    });
+
+    expect(
+      getValidations(
+        {
+          writeOnly: true,
+        },
+        [SchemaNodeKind.Object],
+        {
+          readOnly: true,
+        },
+      ),
+    ).toStrictEqual({
+      readOnly: true,
+    });
+
+    expect(
+      getValidations({}, [SchemaNodeKind.Object], {
+        readOnly: true,
+      }),
+    ).toStrictEqual({
+      readOnly: true,
+    });
+
+    expect(
+      getValidations({}, [SchemaNodeKind.Object], {
+        writeOnly: true,
+      }),
+    ).toStrictEqual({
+      writeOnly: true,
     });
   });
 });

--- a/src/accessors/getValidations.ts
+++ b/src/accessors/getValidations.ts
@@ -30,11 +30,34 @@ function getTypeValidations(types: SchemaNodeKind[]): (keyof SchemaFragment)[] |
   return extraValidations;
 }
 
-export function getValidations(fragment: SchemaFragment, types: SchemaNodeKind[] | null): Dictionary<unknown> {
+export function getValidations(
+  fragment: SchemaFragment,
+  types: SchemaNodeKind[] | null,
+  originalFragment: SchemaFragment | null = null,
+): Dictionary<unknown> {
   const extraValidations = types === null ? null : getTypeValidations(types);
 
+  const fragmentValidations: Dictionary<unknown> = pick(fragment, COMMON_VALIDATION_TYPES);
+
+  if (originalFragment) {
+    const originalValidations: Dictionary<unknown> = pick(originalFragment, COMMON_VALIDATION_TYPES);
+
+    if (originalValidations.readOnly as boolean) {
+      fragmentValidations.readOnly = true;
+      if (fragmentValidations.writeOnly as boolean) {
+        delete fragmentValidations.writeOnly;
+      }
+    }
+    if (originalValidations.writeOnly as boolean) {
+      fragmentValidations.writeOnly = true;
+      if (fragmentValidations.readOnly as boolean) {
+        delete fragmentValidations.readOnly;
+      }
+    }
+  }
+
   return {
-    ...pick(fragment, COMMON_VALIDATION_TYPES),
+    ...fragmentValidations,
     ...(extraValidations !== null ? pick(fragment, extraValidations) : null),
   };
 }

--- a/src/nodes/RegularNode.ts
+++ b/src/nodes/RegularNode.ts
@@ -47,8 +47,8 @@ export class RegularNode extends BaseNode {
     this.title = unwrapStringOrNull(fragment.title);
 
     this.annotations = getAnnotations(fragment);
-    this.validations = getValidations(fragment, this.types);
     this.originalFragment = context?.originalFragment ?? fragment;
+    this.validations = getValidations(fragment, this.types, this.originalFragment);
 
     this.children = void 0;
   }

--- a/src/nodes/mirrored/MirroredRegularNode.ts
+++ b/src/nodes/mirrored/MirroredRegularNode.ts
@@ -1,5 +1,6 @@
 import type { Dictionary } from '@stoplight/types';
 
+import { getValidations } from '../../accessors/getValidations';
 import { isReferenceNode, isRegularNode } from '../../guards';
 import type { SchemaFragment } from '../../types';
 import { isNonNullable } from '../../utils';
@@ -39,7 +40,7 @@ export class MirroredRegularNode extends BaseNode implements RegularNode {
     super();
     this.fragment = mirroredNode.fragment;
     this.originalFragment = context?.originalFragment ?? mirroredNode.originalFragment;
-
+    this.validations = getValidations(this.fragment, null, this.originalFragment);
     this.cache = new WeakMap();
 
     this._this = new Proxy(this, {


### PR DESCRIPTION
Allow usage of readOnly and WriteOnly tags on $ref nodes

fix #34

## Motivation and Context
See #34 

## Description
When setting node validations, the original fragment is also passed to the function to be able to parse `readOnly` and `writeOnly` tags. If no original fragment is provided, the function works as before, to **not** introduce breaking changes. 

## How Has This Been Tested?
Unit tests were added to assure correct validation.

## Screenshot(s)/recordings(s)
See #34 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
